### PR TITLE
ignore foam template files

### DIFF
--- a/_layouts/gatsby-config.js
+++ b/_layouts/gatsby-config.js
@@ -23,6 +23,7 @@ module.exports = {
           '**/.github/**',
           '**/.vscode/**',
           '**/.cache/**',
+          '**/.foam/templates/**'
         ],
         // this is an option for extending `gatsby-plugin-mdx` options inside `gatsby-theme-kb`,
         getPluginMdx(defaultPluginMdx) {


### PR DESCRIPTION
Ignoring [foam template](https://github.com/foambubble/foam-template/blob/master/.foam/templates/your-first-template.md) files in the build.